### PR TITLE
Fix version string build that causes setup.py to fail

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Installation
 
 #. The usual pip or easy_install from `github <https://github.com/pcraciunoiu/django-nginx-memcache>`_::
 
-    pip install -e git://github.com/pcraciunoiu/django-nginx-memcache#egg=django-nginx-memcache
+    pip install -e git://github.com/boyander/django-nginx-memcache#egg=django-nginx-memcache
 
 #. Add ``nginx_memcache`` to your installed apps::
 

--- a/nginx_memcache/__init__.py
+++ b/nginx_memcache/__init__.py
@@ -1,8 +1,8 @@
-VERSION = (0, 1)
-
+VERSION = (
+	0 , # Major 
+	1 , # Minor
+	1 ) # Patches or Sprint version
 
 def get_version():
-    version = '%s.%s' % (VERSION[0], VERSION[1])
-    if VERSION[2]:
-        version = '%s.%s' % (version, VERSION[2])
-    return version
+	version = ".".join(map(str, VERSION))
+	return version

--- a/nginx_memcache/cache.py
+++ b/nginx_memcache/cache.py
@@ -22,7 +22,7 @@ def cache_response(request, response,
         pv = ''
     cache_key = get_cache_key(request.get_full_path(), page_version=pv,
                             cookie_name=cookie_name)
-    nginx_cache.set(cache_key, response._get_content(), cache_timeout)
+    nginx_cache.set(cache_key, response.content, cache_timeout)
     # Store the version, if any specified.
     if pv:
         response.set_cookie(cookie_name, pv)


### PR DESCRIPTION
There's an error that is causing setup.py to fail. This is important for new installations, it causes them to fail when running via pip.
